### PR TITLE
Master Variant MSRP Set to 0 Fix

### DIFF
--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -1,5 +1,5 @@
 def discount_percentage(product)
-  if product.master.msrp.present?
+  if product.master.msrp.present? && (product.master.msrp.to_f > 0)
     "#{((1 - product.price.to_f / product.master.msrp.to_f) * 100).round}%"
   end
 end

--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -1,5 +1,7 @@
 def discount_percentage(product)
   if product.master.msrp.present? && (product.master.msrp.to_f > 0)
     "#{((1 - product.price.to_f / product.master.msrp.to_f) * 100).round}%"
+  else
+    return '0%'
   end
 end

--- a/app/views/spree/shared/_original_price_display.html.erb
+++ b/app/views/spree/shared/_original_price_display.html.erb
@@ -15,7 +15,7 @@
   </span>
 </span>
 
-<% if product.master.msrp.present? %>
+<% if product.master.msrp.present? && (product.master.msrp.to_f > 0) %>
   <span class="save-percent">
     Save <%= discount_percentage(product) %>
   </span>

--- a/app/views/spree/shared/_original_price_display.html.erb
+++ b/app/views/spree/shared/_original_price_display.html.erb
@@ -1,4 +1,4 @@
-<% if product.master.msrp.present? %>
+<% if product.master.msrp.present? && discount_percentage(product) != '0%' %>
   <span class="list-price">
     <strong>
       <span class="line-through">
@@ -15,7 +15,7 @@
   </span>
 </span>
 
-<% if product.master.msrp.present? && (product.master.msrp.to_f > 0) %>
+<% if product.master.msrp.present? && discount_percentage(product) != '0%' %>
   <span class="save-percent">
     Save <%= discount_percentage(product) %>
   </span>


### PR DESCRIPTION
If the master variant of a product is set to 0 the front end will fail. This pull request fixes that by checking that the MSRP is greater than 0 before trying to do calculations with it.
